### PR TITLE
Fixed importlib deprecated warning

### DIFF
--- a/private_media/views.py
+++ b/private_media/views.py
@@ -9,7 +9,7 @@ from . import servers
 import logging
 logger = logging.getLogger(__name__)
 
-from django.utils.importlib import import_module
+from importlib import import_module
 
 def get_class(import_path=None):
     """


### PR DESCRIPTION
django's importlib will be deprecated in 1.9 per
https://docs.djangoproject.com/en/1.8/releases/1.7/#deprecated-features-1-7
